### PR TITLE
Fix #to_param for invalid models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem "byebug"
+
 gemspec

--- a/lib/sluggi/model.rb
+++ b/lib/sluggi/model.rb
@@ -10,7 +10,7 @@ module Sluggi
     end
 
     def to_param
-      slug_was
+      errors.any? ? slug_was : slug
     end
 
     private

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -39,7 +39,6 @@ class ModelTest < MiniTest::Spec
 
   describe "#to_param" do
     before do
-      Cat.delete_all
       @cat = Cat.new(name: "Tuxedo Stan")
     end
 
@@ -52,9 +51,10 @@ class ModelTest < MiniTest::Spec
       assert_equal "tuxedo-stan", @cat.to_param
     end
 
-    it "is the old slug when changed but not saved" do
+    it "is the old slug when record is invalid" do
       @cat.save!
       @cat.slug = "ketzel"
+      @cat.errors.add(:name, "something is wrong")
       assert_equal "tuxedo-stan", @cat.to_param
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,12 @@ require "sqlite3"
 require "sluggi"
 require "mocha/setup"
 
+begin
+  require "byebug"
+rescue LoadError
+  # ok
+end
+
 ActiveRecord::Base.logger = Logger.new(STDERR) if ENV["VERBOSE"]
 
 ActiveRecord::Base.establish_connection(


### PR DESCRIPTION
`#to_param` returns the slug if the model is valid.

If the model is invalid, `#to_param` returns the previous slug value. When an update fails, the new slug value is not yet persisted. In that case, you want the previous `#to_param`/slug value, so that paths/urls for the model are valid.

Before, when `#to_param` was called in an `after_*` callback, calling `#slug_was` caused a warning.