### PR TITLE
Improve migration generator

### DIFF
--- a/lib/generators/create_slugs.erb.rb
+++ b/lib/generators/create_slugs.erb.rb
@@ -1,6 +1,4 @@
-# frozen_string_literal: true
-
-class CreateSlugs < ActiveRecord::Migration
+class CreateSlugs < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     create_table :slugs do |t|
       t.string :slug, null: false

--- a/lib/generators/sluggi_generator.rb
+++ b/lib/generators/sluggi_generator.rb
@@ -6,10 +6,10 @@ require "rails/generators/active_record"
 # Copy the migration to create the slugs table.
 class SluggiGenerator < ActiveRecord::Generators::Base
   argument :name, type: :string, default: "required_but_not_used"
-  source_root File.expand_path("../migrations", __dir__)
+  source_root File.expand_path(__dir__)
 
   # Copy the migration template to db/migrate.
   def copy_files
-    migration_template "create_slugs.rb", "db/migrate/create_slugs.rb"
+    migration_template "create_slugs.erb.rb", "db/migrate/create_slugs.rb"
   end
 end

--- a/lib/sluggi.rb
+++ b/lib/sluggi.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_record"
 require "sluggi/version"
 require "sluggi/slug"
 require "sluggi/history"
@@ -8,4 +9,3 @@ require "sluggi/validate_presence"
 require "sluggi/validate_uniqueness"
 require "sluggi/model"
 require "sluggi/slugged"
-require "sluggi/generators/sluggi_generator"

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -2,9 +2,10 @@
 
 require "test_helper"
 require "rails/generators/test_case"
+require "generators/sluggi_generator"
 
 class GeneratorTest < Rails::Generators::TestCase
-  tests ::SluggiGenerator
+  tests SluggiGenerator
   destination File.expand_path("../tmp", __dir__)
   setup :prepare_destination
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,8 +4,6 @@
 # Coveralls.wear!
 
 require "minitest/autorun"
-require "active_support"
-require "active_record"
 require "sqlite3"
 require "sluggi"
 


### PR DESCRIPTION
* Do not require generator at top level
* Include ActiveRecord version in generated Migration class
* Remove gem dependency on railties